### PR TITLE
support gl.generateMipmap

### DIFF
--- a/src/web/seizer.js
+++ b/src/web/seizer.js
@@ -538,11 +538,12 @@ export default function getPlatformEnv(canvas_element, getInstance) {
         ) {
             const PIXEL_SIZES = {
                 [gl.RGBA]: 4,
+                [gl.RGB]: 4, // shouldn't this be 3?
             };
             const pixel_size = PIXEL_SIZES[format];
 
             // Need to find out the pixel size for more formats
-            if (!format) throw new Error("Unimplemented pixel format");
+            if (!pixel_size) throw new Error("Unimplemented pixel format");
 
             const data =
                 data_ptr != 0
@@ -617,6 +618,9 @@ export default function getPlatformEnv(canvas_element, getInstance) {
         },
         scissor(x, y, width, height) {
             gl.scissor(x, y, width, height);
+        },
+        generateMipmap(mode) {
+            gl.generateMipmap(mode);
         },
     };
 }

--- a/src/web/seizer.js
+++ b/src/web/seizer.js
@@ -538,7 +538,7 @@ export default function getPlatformEnv(canvas_element, getInstance) {
         ) {
             const PIXEL_SIZES = {
                 [gl.RGBA]: 4,
-                [gl.RGB]: 4, // shouldn't this be 3?
+                [gl.RGB]: 3,
             };
             const pixel_size = PIXEL_SIZES[format];
 

--- a/src/web/webgl.zig
+++ b/src/web/webgl.zig
@@ -129,3 +129,4 @@ pub extern fn useProgram(program_id: c_uint) void;
 pub extern fn vertexAttribPointer(attrib_location: c_uint, size: c_uint, type: c_uint, normalize: c_uint, stride: c_uint, offset: ?*const c_void) void;
 pub extern fn viewport(x: c_int, y: c_int, width: c_int, height: c_int) void;
 pub extern fn scissor(x: GLint, y: GLint, width: GLsizei, height: GLsizei) void;
+pub extern fn generateMipmap(mode: GLenum) void;


### PR DESCRIPTION
- gl.texImage2D: add support for passing RGB and fixes its pixel format
  check

@leroycep can you verify that `4` is correct pixel_size for RGB? i thought it should be 3.  both seem to work fine in my charmap code. 